### PR TITLE
Initial implementation of two REST microservices: hello-service and response-service

### DIFF
--- a/hello-service/pom.xml
+++ b/hello-service/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.example</groupId>
-		<artifactId>my-microservices</artifactId>
+		<artifactId>usvc-k8s</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hello-service/src/main/java/com/example/hello_service/controller/HelloController.java
+++ b/hello-service/src/main/java/com/example/hello_service/controller/HelloController.java
@@ -1,0 +1,21 @@
+package com.example.hello_service.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+public class HelloController {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${response.service.url}")
+    private String responseServiceUrl;
+
+    @GetMapping("/hello")
+    public String hello() {
+        String response = restTemplate.getForObject(responseServiceUrl + "/response", String.class);
+        return "Ciao! La risposta è: \"" + response + "\"";
+    }
+}

--- a/hello-service/src/main/resources/application.properties
+++ b/hello-service/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=hello-service
+server.port=8081
+response.service.url=http://localhost:8082

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,37 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.example</groupId>
-    <artifactId>my-microservices</artifactId>
+    <artifactId>usvc-k8s</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <modules>
         <module>hello-service</module>
         <module>response-service</module>
     </modules>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- important -->
+    </parent>
+
     <properties>
         <java.version>17</java.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>3.2.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>
+

--- a/response-service/pom.xml
+++ b/response-service/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.example</groupId>
-		<artifactId>my-microservices</artifactId>
+		<artifactId>usvc-k8s</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/response-service/src/main/java/com/example/response_service/controller/ResponseController.java
+++ b/response-service/src/main/java/com/example/response_service/controller/ResponseController.java
@@ -1,0 +1,13 @@
+package com.example.response_service.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ResponseController {
+
+    @GetMapping("/response")
+    public String response(){
+        return "Ciao, ti rispondo";
+    }
+}

--- a/response-service/src/main/resources/application.properties
+++ b/response-service/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=response-service
+server.port=8082


### PR DESCRIPTION
This PR introduces the first version of two independent Spring Boot microservices. The hello-service exposes the /hello endpoint on port 8081, which responds with a greeting and internally calls the response-service. The response-service exposes the /response endpoint on port 8082, responding with a simple message. Both services have separate application.properties files and are managed as distinct Maven modules under a parent project. The setup allows independent build, test, and deployment, simulating a microservices environment. Included are basic Spring Boot configurations, a parent pom for version and module management, simple REST endpoints without a database, and distinct ports to avoid local conflicts. This foundation will enable extending CI/CD workflows, Kubernetes deployment, and integration with tools like Helm and Flux in the future.