### PR TITLE
Add manual CI workflows for building single or multiple modules

### DIFF
--- a/.github/actions/build-develop.yaml
+++ b/.github/actions/build-develop.yaml
@@ -31,6 +31,6 @@ runs:
         mvn -B clean deploy -DskipTests -s ${{ inputs.setting_maven }} -f ${{ inputs.module }}/pom.xml
       env: 
         GITHUB_TOKEN: ${{inputs.token}}
-        shell: bash
-        
+      shell: bash
+
         

--- a/.github/actions/build-develop.yaml
+++ b/.github/actions/build-develop.yaml
@@ -1,0 +1,36 @@
+name: "Build Develop"
+description: "Build Develop"
+inputs:
+  token:
+    description: "Github PAT"
+    required: true
+  module: 
+    description: "Module directory or . for all modules"
+    required: true
+  setting_maven:
+    description: "Path to Maven settings.xml"
+    required: true
+
+runs:
+  using: "composite"
+  steps: 
+    - name: Check Java and Maven verisions
+      run: |
+        java -version
+        mvn -v
+      shell: bash
+
+    - name: Show content of actions folder
+      run: |
+        ls -la
+      shell: bash
+    
+    - name: Build and deploy with Maven
+      run: |
+        echo "Building module: ${{inputs.module}}"
+        mvn -B clean deploy -DskipTests -s ${{ inputs.setting_maven }} -f ${{ inputs.module }}/pom.xml
+      env: 
+        GITHUB_TOKEN: ${{inputs.token}}
+        shell: bash
+        
+        

--- a/.github/workflows/build-dry.yaml
+++ b/.github/workflows/build-dry.yaml
@@ -22,3 +22,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{inputs.branch}}
+      
+      - name: Build with composite actions
+        uses: ./.github/actions/build-develop
+        with:
+          token: ${{GITHUB_TOKEN}}
+          module: ${{inputs.module}}
+          setting_maven: ".github/maven/settings.xml"

--- a/.github/workflows/build-dry.yaml
+++ b/.github/workflows/build-dry.yaml
@@ -8,6 +8,7 @@ on:
         required: true
         type: string
       branch:
+        description: 'Name of branch directory'
         required: true
         type: string
 

--- a/.github/workflows/build-dry.yaml
+++ b/.github/workflows/build-dry.yaml
@@ -26,6 +26,6 @@ jobs:
       - name: Build with composite actions
         uses: ./.github/actions/build-develop
         with:
-          token: ${{GITHUB_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           module: ${{inputs.module}}
           setting_maven: ".github/maven/settings.xml"

--- a/.github/workflows/build-dry.yaml
+++ b/.github/workflows/build-dry.yaml
@@ -1,0 +1,23 @@
+name: v1 Build branch dry
+
+on:
+  workflow_call:
+    inputs:
+      module:
+        description: 'Name of module directory'
+        required: true
+        type: string
+      branch:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{inputs.branch}}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: v1 Build branch
 
-run-name: Build ${{inputs.modulo}} on branch -> ${{inputs.branch}}
+run-name: Build ${{inputs.module}} on branch -> ${{inputs.branch}}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,39 @@
+name: v1 Build branch
+
+run-name: Build ${{inputs.modulo}} on branch -> ${{inputs.branch}}
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: "Choose which module to build"
+        required: true
+        type: choice
+        options:
+          - all-modules
+          - hello-service
+          - response-service
+      branch:
+        description: "Choose the branch"
+        required: true
+        type: string
+        default: develop
+      
+
+
+jobs:
+  build-single-module:
+    if: ${{ inputs.module != 'all-modules'}}
+    uses: ./.github/workflows/build-dry.yml
+    with:
+      module: ${{inputs.module}}
+      branch: ${{inputs.branch}}
+    secrets: inherit
+
+  build-all-modules:
+    if: ${{ inputs.module == 'all-modules'}}
+    uses: ./.github/workflows/build-dry.yml
+    with:
+      module: "."
+      branch: ${{inputs.branch}}
+    secrets: inherit

--- a/hello-service/pom.xml
+++ b/hello-service/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.example</groupId>
-		<artifactId>my-microservices</artifactId>
+		<artifactId>usvc-k8s</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/hello-service/src/main/java/com/example/hello_service/controller/HelloController.java
+++ b/hello-service/src/main/java/com/example/hello_service/controller/HelloController.java
@@ -1,0 +1,21 @@
+package com.example.hello_service.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+public class HelloController {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${response.service.url}")
+    private String responseServiceUrl;
+
+    @GetMapping("/hello")
+    public String hello() {
+        String response = restTemplate.getForObject(responseServiceUrl + "/response", String.class);
+        return "Ciao! La risposta è: \"" + response + "\"";
+    }
+}

--- a/hello-service/src/main/resources/application.properties
+++ b/hello-service/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=hello-service
+server.port=8081
+response.service.url=http://localhost:8082

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,37 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.example</groupId>
-    <artifactId>my-microservices</artifactId>
+    <artifactId>usvc-k8s</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <modules>
         <module>hello-service</module>
         <module>response-service</module>
     </modules>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- important -->
+    </parent>
+
     <properties>
         <java.version>17</java.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>3.2.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>
+

--- a/response-service/pom.xml
+++ b/response-service/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.example</groupId>
-		<artifactId>my-microservices</artifactId>
+		<artifactId>usvc-k8s</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>

--- a/response-service/src/main/java/com/example/response_service/controller/ResponseController.java
+++ b/response-service/src/main/java/com/example/response_service/controller/ResponseController.java
@@ -1,0 +1,13 @@
+package com.example.response_service.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ResponseController {
+
+    @GetMapping("/response")
+    public String response(){
+        return "Ciao, ti rispondo";
+    }
+}

--- a/response-service/src/main/resources/application.properties
+++ b/response-service/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=response-service
+server.port=8082


### PR DESCRIPTION
This PR introduces GitHub Actions workflows to support manual triggering of Maven builds for individual modules (hello-service, response-service) or all modules together via the parent POM.

Key additions:
- build.yaml: entry-point workflow with workflow_dispatch trigger and user inputs for module and branch.
- build-dry.yaml: reusable workflow handling Maven builds via workflow call.
- build-develop composite action: shared logic for checking Java/Maven and executing the Maven build